### PR TITLE
Allow alternative names for form mon

### DIFF
--- a/RaidBot/Entities/Mons.cs
+++ b/RaidBot/Entities/Mons.cs
@@ -27,6 +27,7 @@ namespace RaidBot.Entities {
                return (id, textInfo.ToTitleCase(name), spriteUrl);
             }
             else {
+               name = GetCorrectName(name);
                mon = await pokeClient.GetResourceAsync<Pokemon>(name);
             }
          }
@@ -67,6 +68,64 @@ namespace RaidBot.Entities {
                "https://raw.githubusercontent.com/PokeMiners/pogo_assets/master/Images/Raids/raid_egg_3_icon_notification.png"
             )}
          };
+      }
+
+      private static string GetCorrectName(string name) {
+         string newName = name;
+
+         var forms = new Dictionary<string, string>() {
+            {"mega", "mega"},
+            {"alolan", "alola"},
+            {"galarian", "galar"},
+            {"alola", "alola"},
+            {"galar", "galar"},
+            {"zen", "zen"},
+            {"normal", "normal"},
+            {"speed", "speed"},
+            {"attack", "attack"},
+            {"defense", "defense"},
+            {"defence", "defense"},
+            {"altered", "altered"},
+            {"rainy", "rainy"},
+            {"snowy", "snowy"},
+            {"sunny", "sunny"},
+            {"black", "black"},
+            {"white", "white"},
+            {"ordinary", "ordinary"},
+            {"resolute", "resolute"},
+            {"therian", "therian"},
+            {"incarnate", "incarnate"}
+         };
+         var otherNames = new Dictionary<string, string>() {
+            {"mega-charizard-x", "charizard-mega-x"},
+            {"mega-charizard-y", "charizard-mega-y"},
+            {"mega-charizard", "charizard-mega-x"},
+            {"charizard-mega", "charizard-mega-x"},
+            {"mega-mewtwo-x", "mewtwo-mega-x"},
+            {"mega-mewtwo-y", "mewtwo-mega-y"},
+            {"mega-mewtwo", "mewtwo-mega-x"},
+            {"mewtwo-mega", "mewtwo-mega-x"},
+            {"giratina", "giratina-altered"},
+            {"deoxys", "deoxys-normal"},
+            {"darmanitan", "darmanitan-standard"},
+            {"tornadus", "tornadus-incarnate"},
+            {"thundurus", "thundurus-incarnate"},
+            {"landorus", "landorus-incarnate"},
+            {"rainy", "rainy"},
+            {"snowy", "snowy"},
+            {"sunny", "sunny"}
+         };
+
+         if (otherNames.ContainsKey(newName)) {
+            return otherNames[newName];
+         }
+
+         string[] nameSplit = newName.Split('-');
+         if (forms.ContainsKey(nameSplit[0])) {
+            newName = nameSplit[1] + '-' + forms[nameSplit[0]];
+         }
+
+         return newName;
       }
    }
 }


### PR DESCRIPTION
Form pokemon (including mega) are usually called "Form MonName", for example "Alolan Marowak". PokeApi needs these names in the format "marowak-alola".

This modification converts alternative names into the right format for PokeApi.

Examples:
Alolan-Marowak will be converted into marowak-alola
Mega-Venusaur will be converted into venusaur-mega
Mega-Charizard-X will be converted into charizard-mega-y
Altered-Giratina will be converted into giratina-altered
Normal-Deoxys will be converted into deoxys-normal
Deoxys will be converted into deoxys-normal